### PR TITLE
Fixed typo on gradient tag

### DIFF
--- a/tkcolorpicker/gradientbar.py
+++ b/tkcolorpicker/gradientbar.py
@@ -78,7 +78,7 @@ class GradientBar(tk.Canvas):
             line.append(rgb_to_hexa(*hue2col(float(i) / width * 360)))
         line = "{" + " ".join(line) + "}"
         self.gradient.put(" ".join([line for j in range(height)]))
-        self.create_image(0, 0, anchor="nw", tags="gardient",
+        self.create_image(0, 0, anchor="nw", tags="gradient",
                           image=self.gradient)
         self.lower("gradient")
 


### PR DESCRIPTION
I'm not sure if this causes/caused any errors anywhere, but it might down the line if someone tries to leverage the tag.